### PR TITLE
feat: Added Quick-Deploy

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,6 +6,10 @@
 	"image": "effectiverange/devc-erdev-vscodeext:latest",
 	"customizations": {
 		"vscode": {
+			"settings": {
+				// Workaround for https://github.com/microsoft/vscode-remote-release/issues/10036
+				"extensions.verifySignature": false
+			},
 			"extensions": [
 				"ms-vscode.extension-test-runner",
 				"ms-vscode.cmake-tools",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,7 +16,7 @@
 			"outFiles": [
 				"${workspaceFolder}/out/**/*.js"
 			],
-			"preLaunchTask": "${defaultBuildTask}",
+			"preLaunchTask": "pretest",
 			"postDebugTask": "posttest"
 		},
 		{
@@ -24,7 +24,7 @@
 			"type": "extensionHost",
 			"request": "launch",
 			"args": [
-				"--extensionDevelopmentPath=${workspaceFolder}", 
+				"--extensionDevelopmentPath=${workspaceFolder}",
 				"--extensionTestsPath=${workspaceFolder}/out/test/suite/index",
 				"-n",
 				"--file-uri=${workspaceFolder}/testwsp/test.code-workspace",
@@ -36,6 +36,5 @@
 			"preLaunchTask": "pretest",
 			"postDebugTask": "posttest"
 		},
-
 	]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,33 +1,33 @@
 // See https://go.microsoft.com/fwlink/?LinkId=733558
 // for the documentation about the tasks.json format
 {
-	"version": "2.0.0",
-	"tasks": [
+    "version": "2.0.0",
+    "tasks": [
         {
-			"type": "npm",
-			"script": "watch",
-			"problemMatcher": "$tsc-watch",
-			"isBackground": true,
-			"presentation": {
-				"reveal": "never"
-			},
-			"group": {
-				"kind": "build",
-				"isDefault": true
-			}
-		},
-		{
+            "type": "npm",
+            "script": "watch",
+            "problemMatcher": "$tsc-watch",
+            "isBackground": true,
+            "presentation": {
+                "reveal": "never"
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
             "label": "build-with-webpack-watch",
             "type": "shell",
-			"problemMatcher": "$ts-webpack-watch",
-			"isBackground": true,
-			"presentation": {
-				"reveal": "never",
-				"group": "watchers"
-			},
-			"group": {
-				"kind": "build",
-			},
+            "problemMatcher": "$ts-webpack-watch",
+            "isBackground": true,
+            "presentation": {
+                "reveal": "never",
+                "group": "watchers"
+            },
+            "group": {
+                "kind": "build",
+            },
             "command": "yarn",
             "args": [
                 "run",
@@ -46,6 +46,17 @@
             ],
         },
         {
+            "label": "watchtests",
+            "group": "build",
+            "isBackground": false,
+            "type": "shell",
+            "command": "yarn",
+            "args": [
+                "run",
+                "watch-tests"
+            ],
+        },
+        {
             "label": "posttest",
             "group": "build",
             "isBackground": false,
@@ -56,5 +67,5 @@
                 "main-dist"
             ],
         },
-	]
+    ]
 }

--- a/package.json
+++ b/package.json
@@ -62,6 +62,12 @@
         "icon": "$(cloud-upload)"
       },
       {
+        "command": "erdev.deployQuickProject",
+        "title": "Quick-Deploy Project",
+        "category": "ER Dev",
+        "icon": "$(zap)"
+      },
+      {
         "command": "erdev.launchProjectExe",
         "title": "Launch Executable",
         "category": "ER Dev",
@@ -72,6 +78,13 @@
         "title": "Deploy Project",
         "category": "ER Dev",
         "icon": "$(cloud-upload)",
+        "when": "view == er-ssh-explorer"
+      },
+      {
+        "command": "er-ssh-explorer.deployQuickProject",
+        "title": "Quick-Deploy Project",
+        "category": "ER Dev",
+        "icon": "$(zap)",
         "when": "view == er-ssh-explorer"
       },
       {
@@ -127,6 +140,10 @@
           "when": "false"
         },
         {
+          "command": "er-ssh-explorer.deployQuickProject",
+          "when": "false"
+        },
+        {
           "command": "er-ssh-explorer.launchProjectExe",
           "when": "false"
         },
@@ -146,17 +163,22 @@
         {
           "command": "er-ssh-explorer.deployProject",
           "when": "view == er-ssh-explorer && viewItem == erdevice",
-          "group": "inline"
+          "group": "inline@1"
+        },
+        {
+          "command": "er-ssh-explorer.deployQuickProject",
+          "when": "view == er-ssh-explorer && viewItem == erdevice",
+          "group": "inline@2"
         },
         {
           "command": "er-ssh-explorer.launchProjectExe",
           "when": "view == er-ssh-explorer && viewItem == erdevice",
-          "group": "inline"
+          "group": "inline@3"
         },
         {
           "command": "er-ssh-explorer.terminal",
           "when": "view == er-ssh-explorer && viewItem == erdevice",
-          "group": "inline"
+          "group": "inline@4"
         }
       ]
     },
@@ -183,7 +205,7 @@
     "package": "vsce package --yarn --out ./build/",
     "pretest": "yarn run compile-tests && yarn run lint",
     "compile-tests": "yarn run main-out && tsc -p . --outDir out",
-    "watch-tests": "tsc -p . -w --outDir out",
+    "watch-tests": "yarn run main-out && tsc -p . -w --outDir out",
     "test": "yarn run pretest && node ./out/test/runTest.js",
     "lint": "eslint src --ext ts",
     "coverage": "c8 --all --100 yarn run test",

--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
     "configuration": {
       "title": "ER Dev Extension settings",
       "properties": {
-        "er-dev.sshconfig": {
+        "erdev.sshconfig": {
           "type": "string",
           "default": "~/.ssh/config",
           "description": "The path to the ssh config file to use the host definitions from"

--- a/resources/scripts/deploy_ssh.sh
+++ b/resources/scripts/deploy_ssh.sh
@@ -6,36 +6,53 @@
 
 set -e -x -o pipefail
 SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
-if [ -z $2 ]; then
-    echo "Usage: $0 <project type> <workspace dir> <target> [<extra ssh args>]..."
+if [ -z $2 ] || { [ $3 != "quick" ] && [ $3 != "all" ]; }; then
+    echo "Usage: $0 <project type> <workspace dir> <'quick'|'all'> <target> [<extra ssh args>]..."
     exit 1
 fi
 
+
 PACK_SCRIPT="$SCRIPT_DIR/pack_$1.sh"
+WSPDIR=$2
+TYPE=$3
+TARGET=$4
+
 if [ ! -f "$PACK_SCRIPT"  ]; then
     echo "No pack script found for project type $1"
     exit 1
 fi
 
-TARGET=$3
+if [ ! -d "$WSPDIR" ]; then
+    echo "Workspace directory $WSPDIR does not exist"
+    exit 1
+fi
 
 if [ -z $TARGET ]; then
     echo "No target specified"
     exit 1
 fi
 
+shift 4
 
-DEB_FILES_LIST="$("$PACK_SCRIPT" "$2")"
+DEB_FILES_LIST="$("$PACK_SCRIPT" "$WSPDIR")"
 
 for file in "$DEB_FILES_LIST"
 do
 DEB_FILES_NAMES="$DEB_FILES_NAMES ./$(basename $file)"
 done
 
-
-shift 3
 echo "Deploying $DEB_FILES_NAMES to $TARGET ..."
 
 ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -q "$@" "$TARGET" "mkdir -p /tmp/erdev/"
-scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "$@"  $(echo $DEB_FILES_LIST | tr '\n' ' ') "$TARGET:/tmp/erdev/"
-ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -q  "$@" "$TARGET" "cd /tmp/erdev/ && sudo apt install -y --reinstall --no-install-recommends $DEB_FILES_NAMES" 
+
+SSHARGS="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -q $@"
+rsync -avzc --progress -e "$SSHARGS" $(echo $DEB_FILES_LIST | tr '\n' ' ') "$TARGET:/tmp/erdev/"
+
+if [ $TYPE == "quick" ]; then
+    ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -q  "$@" "$TARGET" "cd /tmp/erdev/ && sudo dpkg -i $DEB_FILES_NAMES"
+elif [ $TYPE == "all" ]; then
+    ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -q  "$@" "$TARGET" "cd /tmp/erdev/ && sudo apt install -y --reinstall --no-install-recommends $DEB_FILES_NAMES" 
+else
+    echo "Deployment type $TYPE unknown!"
+    exit 1
+fi

--- a/src/erdevexecutions.ts
+++ b/src/erdevexecutions.ts
@@ -144,6 +144,7 @@ export abstract class IErDevExecutions {
         provider: ErDevSSHTreeDataProvider,
         target?: ErDeviceModel,
         workspaceFolder?: vscode.WorkspaceFolder,
+        quick: boolean = false,
     ): Promise<void> {
         if (workspaceFolder === undefined) {
             showNoWorkspaceWarning();
@@ -153,7 +154,7 @@ export abstract class IErDevExecutions {
         return this.buildProject(workspaceFolder)
             .then(() => setActiveDeviceIfMissing(this.erext.logChannel, provider, target))
             .then(async (activeTarget) => {
-                const res = await this.execDeploy(activeTarget, workspaceFolder);
+                const res = await this.execDeploy(activeTarget, workspaceFolder, quick);
                 if (res !== 0) {
                     this.erext.logChannel.error('Deployment failed!');
                 }
@@ -163,6 +164,7 @@ export abstract class IErDevExecutions {
     private async execDeploy(
         target: ErDeviceModel,
         workspaceFolder: vscode.WorkspaceFolder,
+        quick: boolean = false,
     ): Promise<number | void> {
         const packScript = this.packScriptName(workspaceFolder);
         if (packScript === undefined) {
@@ -176,6 +178,7 @@ export abstract class IErDevExecutions {
             this.deploySshScriptPath,
             packScript,
             workspaceFolder.uri.fsPath,
+            quick ? 'quick' : 'all',
             toHost(target),
             ...identityArgs(target),
         );

--- a/src/erdevproviders.ts
+++ b/src/erdevproviders.ts
@@ -29,6 +29,7 @@ export class ErDevSSHTreeDataProvider implements vscode.TreeDataProvider<Item> {
     getChildren(element?: ErDeviceItem): Thenable<Item[]> {
         let config = vscode.workspace.getConfiguration('erdev');
         let configfile = (config.get('sshconfig') as string) ?? '~/.ssh/config';
+        this.model.extension.logChannel.info(`Populating SSH configuration from ${configfile}`);
         let parser = new sshparser.SSHParser(configfile);
         if (parser.hasConfig()) {
             return Promise.resolve(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,14 @@ export function activate(context: vscode.ExtensionContext): ErDevApi {
     let erExec = new DispatchExecution(erExt);
     let deviceExec = new SSHDeviceExecution(erExt);
     let erProvider = new ErDevSSHTreeDataProvider(model);
+
+    context.subscriptions.push(
+        vscode.workspace.onDidChangeConfiguration((event) => {
+            if (event.affectsConfiguration('erdev.sshconfig')) {
+                erProvider.refresh();
+            }
+        }),
+    );
     const erDevSSHExplorer = vscode.window.createTreeView('er-ssh-explorer', {
         treeDataProvider: erProvider,
         canSelectMany: false,


### PR DESCRIPTION
- Addresses #1 : Added a `Quick-Deploy` function, that installs the debian package with dpkg. This speeds up deployment, however if a new package dependency is added, then it will be failed to install to the target device, in that case the regular deploy will still use apt install
- Switched to rsync with compression instead of scp for transferring the debian package files to target
-  Added workaround for devcontainer extension installation bug https://github.com/microsoft/vscode-remote-release/issues/10036 
- Fixed issue with sshconfig path handling